### PR TITLE
Make header variables extern

### DIFF
--- a/kdump-elftool.h
+++ b/kdump-elftool.h
@@ -79,9 +79,9 @@ int copy_elf_notes(struct elfc *out, struct elfc *in,
 /*
  * Extracted information about which OS version we are running.
  */
-char *osrelease;
-int os_major_release;
-int os_minor_release;
+extern char *osrelease;
+extern int os_major_release;
+extern int os_minor_release;
 
 /*
  * Scan the vmcoreinfo in the notes looking for values.  A value


### PR DESCRIPTION
Fix duplicated variable on link:
ld: oldmem.o:/usr/src/debug/kdump-elftool/1.4.0-r0/build/../kdump-elftool-1.4.0/kdump-elftool.h:69: multiple definition of `osrelease'; kdump-elftool.o:/usr/src/debug/kdump-elftool/1.4.0-r0/build/../kdump-elftool-1.4.0/kdump-elftool.h:69: first defined here

Signed-off-by: Jeremy Puhlman <jpuhlman@mvista.com>